### PR TITLE
Release v1.1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Mattéo Legagneux @debaze
+Copyright (c) 2025 Atalante @atalantestudio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lyah
 
-Lyah is a C++ SIMD mathematics library for computer graphics. It features 2D-4D vectors, 2x2-4x4 square matrices and quaternions, along with common mathematical functions. It is header-only, fully [tested](https://github.com/debaze/lyah/tree/test) and [documented](https://debaze.github.io/lyah), and can be easily integrated into other projects.
+Lyah is a C++ SIMD mathematics library for computer graphics. It features 2D-4D vectors, 2x2-4x4 square matrices and quaternions, along with common mathematical functions. It is header-only, fully [tested](https://github.com/atalantestudio/lyah/tree/test) and [documented](https://debaze.github.io/lyah), and can be easily integrated into other projects.
 
-Lyah is licensed by the [MIT License](https://github.com/debaze/lyah/blob/main/LICENSE).
+Lyah is licensed by the [MIT License](https://github.com/atalantestudio/lyah/blob/main/LICENSE).

--- a/lyah/base.hpp
+++ b/lyah/base.hpp
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <immintrin.h>
 #include <limits>
 

--- a/lyah/common.hpp
+++ b/lyah/common.hpp
@@ -6,19 +6,19 @@
 #include "base.hpp"
 
 namespace lyah {
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::float_t abs(std::float_t a) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::float_t LYAH_CALL abs(std::float_t a) {
 		return std::fabsf(a);
 	}
 
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::double_t abs(std::double_t a) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::double_t LYAH_CALL abs(std::double_t a) {
 		return std::fabsl(a);
 	}
 
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::int32_t abs(std::int32_t a) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::int32_t LYAH_CALL abs(std::int32_t a) {
 		return static_cast<std::int32_t>(std::fabs(a));
 	}
 
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::int64_t abs(std::int64_t a) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::int64_t LYAH_CALL abs(std::int64_t a) {
 		return static_cast<std::int64_t>(std::fabs(a));
 	}
 

--- a/lyah/exponential.hpp
+++ b/lyah/exponential.hpp
@@ -6,12 +6,12 @@
 #include "base.hpp"
 
 namespace lyah {
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::double_t LYAH_CALL pow(std::double_t a, std::double_t e) {
-		return std::powl(a, e);
-	}
-
 	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::float_t LYAH_CALL pow(std::float_t a, std::float_t e) {
 		return std::powf(a, e);
+	}
+
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::double_t LYAH_CALL pow(std::double_t a, std::double_t e) {
+		return std::powl(a, e);
 	}
 
 	template<typename T>

--- a/lyah/exponential.hpp
+++ b/lyah/exponential.hpp
@@ -6,11 +6,11 @@
 #include "base.hpp"
 
 namespace lyah {
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::double_t pow(std::double_t a, std::double_t e) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::double_t LYAH_CALL pow(std::double_t a, std::double_t e) {
 		return std::powl(a, e);
 	}
 
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::float_t pow(std::float_t a, std::float_t e) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::float_t LYAH_CALL pow(std::float_t a, std::float_t e) {
 		return std::powf(a, e);
 	}
 
@@ -24,11 +24,11 @@ namespace lyah {
 		return static_cast<T>(1) / a;
 	}
 
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::float_t sqrt(std::float_t a) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::float_t LYAH_CALL sqrt(std::float_t a) {
 		return std::sqrtf(a);
 	}
 
-	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::double_t sqrt(std::double_t a) {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::double_t LYAH_CALL sqrt(std::double_t a) {
 		return std::sqrtl(a);
 	}
 

--- a/lyah/mat/mat.ipp
+++ b/lyah/mat/mat.ipp
@@ -91,7 +91,7 @@ namespace lyah {
 	}
 
 	template<typename T>
-	LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE T LYAH_CALL determinant(mat<2, 2, T> a) {
+	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL determinant(mat<2, 2, T> a) {
 		return a[0][0] * a[1][1] - a[0][1] * a[1][0];
 	}
 

--- a/lyah/mat/mat2x2.hpp
+++ b/lyah/mat/mat2x2.hpp
@@ -17,20 +17,22 @@ namespace lyah {
 
 		vec<2, T> m[2];
 
-		LYAH_NODISCARD LYAH_INLINE mat() : m{} {}
+		LYAH_NODISCARD LYAH_INLINE mat() :
+			m{}
+		{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(
-			T m00, T m01,
-			T m10, T m11
-		) : m{
-			{m00, m01},
-			{m10, m11},
-		} {}
+		LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m10, T m11) :
+			m{{m00, m01}, {m10, m11}}
+		{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(vec<2, T> m0, vec<2, T> m1) : m{m0, m1} {}
+		LYAH_NODISCARD LYAH_INLINE mat(vec<2, T> m0, vec<2, T> m1) :
+			m{m0, m1}
+		{}
 
 		template<typename U>
-		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<2, 2, U> a) : m{vec<2, T>(a.m[0]), vec<2, T>(a.m[1])} {}
+		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<2, 2, U> a) :
+			m{vec<2, T>(a.m[0]), vec<2, T>(a.m[1])}
+		{}
 
 		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<2, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
 			LYAH_ASSERT(index < 2);

--- a/lyah/mat/mat3x3.hpp
+++ b/lyah/mat/mat3x3.hpp
@@ -45,34 +45,22 @@ namespace lyah {
 
 		vec<3, T> m[3];
 
-		LYAH_NODISCARD LYAH_INLINE mat() : m{} {}
+		LYAH_NODISCARD LYAH_INLINE mat() :
+			m{}
+		{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(
-			T m00, T m01, T m02,
-			T m10, T m11, T m12,
-			T m20, T m21, T m22
-		) : m{
-			{m00, m01, m02},
-			{m10, m11, m12},
-			{m20, m21, m22},
-		} {}
+		LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m02, T m10, T m11, T m12, T m20, T m21, T m22) :
+			m{{m00, m01, m02}, {m10, m11, m12}, {m20, m21, m22}}
+		{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(
-			vec<3, T> m0,
-			vec<3, T> m1,
-			vec<3, T> m2
-		) : m{
-			m0,
-			m1,
-			m2,
-		} {}
+		LYAH_NODISCARD LYAH_INLINE mat(vec<3, T> m0, vec<3, T> m1, vec<3, T> m2) :
+			m{m0, m1, m2}
+		{}
 
 		template<typename U>
-		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<3, 3, U> a) : m{
-			vec<3, T>(a.m[0]),
-			vec<3, T>(a.m[1]),
-			vec<3, T>(a.m[2]),
-		} {}
+		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<3, 3, U> a) :
+			m{vec<3, T>(a.m[0]), vec<3, T>(a.m[1]), vec<3, T>(a.m[2])}
+		{}
 
 		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<3, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
 			LYAH_ASSERT(index < 3);

--- a/lyah/mat/mat4x4.hpp
+++ b/lyah/mat/mat4x4.hpp
@@ -76,28 +76,26 @@ namespace lyah {
 
 		vec<4, T> m[4];
 
-		LYAH_NODISCARD LYAH_INLINE mat() : m{} {}
+		LYAH_NODISCARD LYAH_INLINE mat() :
+			m{}
+		{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(
-			T m00, T m01, T m02, T m03,
-			T m10, T m11, T m12, T m13,
-			T m20, T m21, T m22, T m23,
-			T m30, T m31, T m32, T m33
-		) : m{
-			{m00, m01, m02, m03},
-			{m10, m11, m12, m13},
-			{m20, m21, m22, m23},
-			{m30, m31, m32, m33},
-		} {}
+		LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m02, T m03, T m10, T m11, T m12, T m13, T m20, T m21, T m22, T m23, T m30, T m31, T m32, T m33) :
+			m{{m00, m01, m02, m03}, {m10, m11, m12, m13}, {m20, m21, m22, m23}, {m30, m31, m32, m33}}
+		{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(vec<4, T> m0, vec<4, T> m1, vec<4, T> m2, vec<4, T> m3) : m{m0, m1, m2, m3} {}
+		LYAH_NODISCARD LYAH_INLINE mat(vec<4, T> m0, vec<4, T> m1, vec<4, T> m2, vec<4, T> m3) :
+			m{m0, m1, m2, m3}
+		{}
 
 		// Returns a rotation matrix computed from a.
 		// a is assumed to be normalized.
 		LYAH_NODISCARD explicit mat(quat<T> a);
 
 		template<typename U>
-		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<4, 4, U> a) : m{vec<4, T>(a.m[0]), vec<4, T>(a.m[1]), vec<4, T>(a.m[2]), vec<4, T>(a.m[3])} {}
+		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<4, 4, U> a) :
+			m{vec<4, T>(a.m[0]), vec<4, T>(a.m[1]), vec<4, T>(a.m[2]), vec<4, T>(a.m[3])}
+		{}
 
 		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<4, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
 			LYAH_ASSERT(index < 4);

--- a/lyah/quat/quat.ipp
+++ b/lyah/quat/quat.ipp
@@ -16,11 +16,15 @@ namespace lyah {
 	}
 
 	template<typename T>
-	LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE quat<T>::quat(__m_t m) : m(m) {}
+	LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE quat<T>::quat(__m_t m) :
+		m(m)
+	{}
 
 	template<typename T>
 	template<typename U>
-	LYAH_NODISCARD LYAH_INLINE quat<T>::quat(quat<U> a) : m(internal::convert<typename quat<U>::__m_t, __m_t>(a.m)) {}
+	LYAH_NODISCARD LYAH_INLINE quat<T>::quat(quat<U> a) :
+		m(internal::convert<typename quat<U>::__m_t, __m_t>(a.m))
+	{}
 
 	template<typename T>
 	LYAH_NODISCARD LYAH_INLINE T quat<T>::w() const {

--- a/lyah/quat/quat_m128.ipp
+++ b/lyah/quat/quat_m128.ipp
@@ -5,11 +5,15 @@
 
 namespace lyah {
 	// NOTE: SSE
-	LYAH_INLINE quat<std::float_t>::quat() : m(_mm_setzero_ps()) {}
+	LYAH_INLINE quat<std::float_t>::quat() :
+		m(_mm_setzero_ps())
+	{}
 
 	// NOTE: SSE
 	template<>
-	LYAH_INLINE quat<std::float_t>::quat(std::float_t w, std::float_t x, std::float_t y, std::float_t z) : m(_mm_set_ps(z, y, x, w)) {}
+	LYAH_INLINE quat<std::float_t>::quat(std::float_t w, std::float_t x, std::float_t y, std::float_t z) :
+		m(_mm_set_ps(z, y, x, w))
+	{}
 
 	// NOTE: SSE
 	LYAH_INLINE std::float_t quat<std::float_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/quat/quat_m256d.ipp
+++ b/lyah/quat/quat_m256d.ipp
@@ -5,11 +5,15 @@
 
 namespace lyah {
 	// NOTE: AVX
-	LYAH_INLINE quat<std::double_t>::quat() : m(_mm256_setzero_pd()) {}
+	LYAH_INLINE quat<std::double_t>::quat() :
+		m(_mm256_setzero_pd())
+	{}
 
 	// NOTE: AVX
 	template<>
-	LYAH_INLINE quat<std::double_t>::quat(std::double_t w, std::double_t x, std::double_t y, std::double_t z) : m(_mm256_set_pd(z, y, x, w)) {}
+	LYAH_INLINE quat<std::double_t>::quat(std::double_t w, std::double_t x, std::double_t y, std::double_t z) :
+		m(_mm256_set_pd(z, y, x, w))
+	{}
 
 	// NOTE: AVX2
 	LYAH_INLINE std::double_t quat<std::double_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/quat/quat_m256d.ipp
+++ b/lyah/quat/quat_m256d.ipp
@@ -29,14 +29,14 @@ namespace lyah {
 		return vec<3, std::double_t>(_mm256_permute4x64_pd(m, _MM_SHUFFLE(0, 3, 2, 1)));
 	}
 
-	// NOTE: AVX2
+	// NOTE: AVX
 	LYAH_NODISCARD LYAH_INLINE bool LYAH_CALL operator ==(quat<std::double_t> a, quat<std::double_t> b) {
 		const __m256d m = _mm256_cmp_pd(a.m, b.m, _CMP_NEQ_OQ);
 
 		return _mm256_movemask_pd(m) == 0;
 	}
 
-	// NOTE: AVX2
+	// NOTE: AVX
 	LYAH_NODISCARD LYAH_INLINE bool LYAH_CALL operator !=(quat<std::double_t> a, quat<std::double_t> b) {
 		const __m256d m = _mm256_cmp_pd(a.m, b.m, _CMP_NEQ_OQ);
 

--- a/lyah/vec/m128/base.ipp
+++ b/lyah/vec/m128/base.ipp
@@ -6,7 +6,7 @@ namespace lyah {
 	// https://stackoverflow.com/a/6042506
 	template<std::size_t C>
 	LYAH_NODISCARD LYAH_INLINE bool LYAH_CALL operator ==(vec<C, std::float_t> a, vec<C, std::float_t> b) {
-		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2, C)) - 1;
+		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2.0f, static_cast<std::float_t>(C))) - 1;
 
 		const __m128 m = _mm_cmpneq_ps(a.m, b.m);
 		const std::int32_t mask = _mm_movemask_ps(m) & bitMask;
@@ -18,7 +18,7 @@ namespace lyah {
 	// https://stackoverflow.com/a/6042506
 	template<std::size_t C>
 	LYAH_NODISCARD LYAH_INLINE bool LYAH_CALL operator !=(vec<C, std::float_t> a, vec<C, std::float_t> b) {
-		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2, C)) - 1;
+		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2.0f, static_cast<std::float_t>(C))) - 1;
 
 		const __m128 m = _mm_cmpneq_ps(a.m, b.m);
 		const std::int32_t mask = _mm_movemask_ps(m) & bitMask;

--- a/lyah/vec/m256d/base.ipp
+++ b/lyah/vec/m256d/base.ipp
@@ -6,7 +6,7 @@ namespace lyah {
 	// https://stackoverflow.com/a/64191351
 	template<std::size_t C>
 	LYAH_NODISCARD LYAH_INLINE bool LYAH_CALL operator ==(vec<C, std::double_t> a, vec<C, std::double_t> b) {
-		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2, C)) - 1;
+		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2.0f, static_cast<std::float_t>(C))) - 1;
 
 		const __m256d m = _mm256_cmp_pd(a.m, b.m, _CMP_NEQ_OQ);
 		const std::int32_t mask = _mm256_movemask_pd(m) & bitMask;
@@ -17,7 +17,7 @@ namespace lyah {
 	// NOTE: AVX
 	template<std::size_t C>
 	LYAH_NODISCARD LYAH_INLINE bool LYAH_CALL operator !=(vec<C, std::double_t> a, vec<C, std::double_t> b) {
-		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2, C)) - 1;
+		static LYAH_CONSTEXPR_CPP26 const std::int32_t bitMask = static_cast<std::int32_t>(pow(2.0f, static_cast<std::float_t>(C))) - 1;
 
 		const __m256d m = _mm256_cmp_pd(a.m, b.m, _CMP_NEQ_OQ);
 		const std::int32_t mask = _mm256_movemask_pd(m) & bitMask;

--- a/lyah/vec/vec2.hpp
+++ b/lyah/vec/vec2.hpp
@@ -17,7 +17,10 @@ namespace lyah {
 		LYAH_NODISCARD vec();
 		LYAH_NODISCARD vec(T x, T y);
 		LYAH_NODISCARD explicit vec(T a);
-		LYAH_NODISCARD LYAH_CONSTEXPR explicit vec(__m_t m) : m(m) {}
+
+		LYAH_NODISCARD LYAH_CONSTEXPR explicit vec(__m_t m) :
+			m(m)
+		{}
 
 		template<typename U>
 		LYAH_NODISCARD explicit vec(vec<2, U> a) : m(internal::convert<typename vec<2, U>::__m_t, __m_t>(a.m)) {}

--- a/lyah/vec/vec2.hpp
+++ b/lyah/vec/vec2.hpp
@@ -18,7 +18,7 @@ namespace lyah {
 		LYAH_NODISCARD vec(T x, T y);
 		LYAH_NODISCARD explicit vec(T a);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR explicit vec(__m_t m) :
+		LYAH_NODISCARD explicit vec(__m_t m) :
 			m(m)
 		{}
 

--- a/lyah/vec/vec2_m128.ipp
+++ b/lyah/vec/vec2_m128.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: SSE
-	LYAH_INLINE vec<2, std::float_t>::vec() : m(_mm_setzero_ps()) {}
+	LYAH_INLINE vec<2, std::float_t>::vec() :
+		m(_mm_setzero_ps())
+	{}
 
 	// NOTE: SSE
-	LYAH_INLINE vec<2, std::float_t>::vec(std::float_t x, std::float_t y) : m(_mm_set_ps(0.0f, 0.0f, y, x)) {}
+	LYAH_INLINE vec<2, std::float_t>::vec(std::float_t x, std::float_t y) :
+		m(_mm_set_ps(0.0f, 0.0f, y, x))
+	{}
 
 	// NOTE: SSE
-	LYAH_INLINE vec<2, std::float_t>::vec(std::float_t a) : m(_mm_set1_ps(a)) {}
+	LYAH_INLINE vec<2, std::float_t>::vec(std::float_t a) :
+		m(_mm_set1_ps(a))
+	{}
 
 	// NOTE: SSE
 	LYAH_INLINE std::float_t vec<2, std::float_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec2_m128d.ipp
+++ b/lyah/vec/vec2_m128d.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: SSE2
-	LYAH_INLINE vec<2, std::double_t>::vec() : m(_mm_setzero_pd()) {}
+	LYAH_INLINE vec<2, std::double_t>::vec() :
+		m(_mm_setzero_pd())
+	{}
 
 	// NOTE: SSE2
-	LYAH_INLINE vec<2, std::double_t>::vec(std::double_t x, std::double_t y) : m(_mm_set_pd(y, x)) {}
+	LYAH_INLINE vec<2, std::double_t>::vec(std::double_t x, std::double_t y) :
+		m(_mm_set_pd(y, x))
+	{}
 
 	// NOTE: SSE2
-	LYAH_INLINE vec<2, std::double_t>::vec(std::double_t a) : m(_mm_set1_pd(a)) {}
+	LYAH_INLINE vec<2, std::double_t>::vec(std::double_t a) :
+		m(_mm_set1_pd(a))
+	{}
 
 	// NOTE: SSE2
 	LYAH_INLINE std::double_t vec<2, std::double_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec2_m128i.ipp
+++ b/lyah/vec/vec2_m128i.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: SSE2
-	LYAH_INLINE vec<2, std::int64_t>::vec() : m(_mm_setzero_si128()) {}
+	LYAH_INLINE vec<2, std::int64_t>::vec() :
+		m(_mm_setzero_si128())
+	{}
 
 	// NOTE: SSE2
-	LYAH_INLINE vec<2, std::int64_t>::vec(std::int64_t x, std::int64_t y) : m(_mm_set_epi64x(y, x)) {}
+	LYAH_INLINE vec<2, std::int64_t>::vec(std::int64_t x, std::int64_t y) :
+		m(_mm_set_epi64x(y, x))
+	{}
 
 	// NOTE: SSE2
-	LYAH_INLINE vec<2, std::int64_t>::vec(std::int64_t a) : m(_mm_set1_epi64x(a)) {}
+	LYAH_INLINE vec<2, std::int64_t>::vec(std::int64_t a) :
+		m(_mm_set1_epi64x(a))
+	{}
 
 	// NOTE: SSE2
 	LYAH_INLINE std::int64_t vec<2, std::int64_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec3.hpp
+++ b/lyah/vec/vec3.hpp
@@ -18,7 +18,7 @@ namespace lyah {
 		LYAH_NODISCARD vec(T x, T y, T z);
 		LYAH_NODISCARD explicit vec(T a);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR explicit vec(__m_t m) :
+		LYAH_NODISCARD explicit vec(__m_t m) :
 			m(m)
 		{}
 

--- a/lyah/vec/vec3.hpp
+++ b/lyah/vec/vec3.hpp
@@ -17,7 +17,10 @@ namespace lyah {
 		LYAH_NODISCARD vec();
 		LYAH_NODISCARD vec(T x, T y, T z);
 		LYAH_NODISCARD explicit vec(T a);
-		LYAH_NODISCARD LYAH_CONSTEXPR explicit vec(__m_t m) : m(m) {}
+
+		LYAH_NODISCARD LYAH_CONSTEXPR explicit vec(__m_t m) :
+			m(m)
+		{}
 
 		template<typename U>
 		LYAH_NODISCARD explicit vec(vec<3, U> a) : m(internal::convert<typename vec<3, U>::__m_t, __m_t>(a.m)) {}

--- a/lyah/vec/vec3_m128.ipp
+++ b/lyah/vec/vec3_m128.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: SSE
-	LYAH_INLINE vec<3, std::float_t>::vec() : m(_mm_setzero_ps()) {}
+	LYAH_INLINE vec<3, std::float_t>::vec() :
+		m(_mm_setzero_ps())
+	{}
 
 	// NOTE: SSE
-	LYAH_INLINE vec<3, std::float_t>::vec(std::float_t x, std::float_t y, std::float_t z) : m(_mm_set_ps(0.0f, z, y, x)) {}
+	LYAH_INLINE vec<3, std::float_t>::vec(std::float_t x, std::float_t y, std::float_t z) :
+		m(_mm_set_ps(0.0f, z, y, x))
+	{}
 
 	// NOTE: SSE
-	LYAH_INLINE vec<3, std::float_t>::vec(std::float_t a) : m(_mm_set1_ps(a)) {}
+	LYAH_INLINE vec<3, std::float_t>::vec(std::float_t a) :
+		m(_mm_set1_ps(a))
+	{}
 
 	// NOTE: SSE
 	LYAH_INLINE std::float_t vec<3, std::float_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec3_m256d.ipp
+++ b/lyah/vec/vec3_m256d.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: AVX
-	LYAH_INLINE vec<3, std::double_t>::vec() : m(_mm256_setzero_pd()) {}
+	LYAH_INLINE vec<3, std::double_t>::vec() :
+		m(_mm256_setzero_pd())
+	{}
 
 	// NOTE: AVX
-	LYAH_INLINE vec<3, std::double_t>::vec(std::double_t x, std::double_t y, std::double_t z) : m(_mm256_set_pd(0.0, z, y, x)) {}
+	LYAH_INLINE vec<3, std::double_t>::vec(std::double_t x, std::double_t y, std::double_t z) :
+		m(_mm256_set_pd(0.0, z, y, x))
+	{}
 
 	// NOTE: AVX
-	LYAH_INLINE vec<3, std::double_t>::vec(std::double_t a) : m(_mm256_set1_pd(a)) {}
+	LYAH_INLINE vec<3, std::double_t>::vec(std::double_t a) :
+		m(_mm256_set1_pd(a))
+	{}
 
 	// NOTE: AVX2
 	LYAH_INLINE std::double_t vec<3, std::double_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec4.hpp
+++ b/lyah/vec/vec4.hpp
@@ -17,7 +17,10 @@ namespace lyah {
 		LYAH_NODISCARD vec();
 		LYAH_NODISCARD vec(T x, T y, T z, T w);
 		LYAH_NODISCARD explicit vec(T a);
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE explicit vec(__m_t m) : m(m) {}
+
+		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE explicit vec(__m_t m) :
+			m(m)
+		{}
 
 		template<typename U>
 		LYAH_NODISCARD explicit vec(vec<4, U> a) : m(internal::convert<typename vec<4, U>::__m_t, __m_t>(a.m)) {}

--- a/lyah/vec/vec4.hpp
+++ b/lyah/vec/vec4.hpp
@@ -18,7 +18,7 @@ namespace lyah {
 		LYAH_NODISCARD vec(T x, T y, T z, T w);
 		LYAH_NODISCARD explicit vec(T a);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE explicit vec(__m_t m) :
+		LYAH_NODISCARD LYAH_INLINE explicit vec(__m_t m) :
 			m(m)
 		{}
 

--- a/lyah/vec/vec4_m128.ipp
+++ b/lyah/vec/vec4_m128.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: SSE
-	LYAH_INLINE vec<4, std::float_t>::vec() : m(_mm_setzero_ps()) {}
+	LYAH_INLINE vec<4, std::float_t>::vec() :
+		m(_mm_setzero_ps())
+	{}
 
 	// NOTE: SSE
-	LYAH_INLINE vec<4, std::float_t>::vec(std::float_t x, std::float_t y, std::float_t z, std::float_t w) : m(_mm_set_ps(w, z, y, x)) {}
+	LYAH_INLINE vec<4, std::float_t>::vec(std::float_t x, std::float_t y, std::float_t z, std::float_t w) :
+		m(_mm_set_ps(w, z, y, x))
+	{}
 
 	// NOTE: SSE
-	LYAH_INLINE vec<4, std::float_t>::vec(std::float_t a) : m(_mm_set1_ps(a)) {}
+	LYAH_INLINE vec<4, std::float_t>::vec(std::float_t a) :
+		m(_mm_set1_ps(a))
+	{}
 
 	// NOTE: SSE
 	LYAH_INLINE std::float_t vec<4, std::float_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec4_m128i.ipp
+++ b/lyah/vec/vec4_m128i.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: SSE2
-	LYAH_INLINE vec<4, std::int32_t>::vec() : m(_mm_setzero_si128()) {}
+	LYAH_INLINE vec<4, std::int32_t>::vec() :
+		m(_mm_setzero_si128())
+	{}
 
 	// NOTE: SSE2
-	LYAH_INLINE vec<4, std::int32_t>::vec(std::int32_t x, std::int32_t y, std::int32_t z, std::int32_t w) : m(_mm_set_epi32(w, z, y, x)) {}
+	LYAH_INLINE vec<4, std::int32_t>::vec(std::int32_t x, std::int32_t y, std::int32_t z, std::int32_t w) :
+		m(_mm_set_epi32(w, z, y, x))
+	{}
 
 	// NOTE: SSE2
-	LYAH_INLINE vec<4, std::int32_t>::vec(std::int32_t a) : m(_mm_set1_epi32(a)) {}
+	LYAH_INLINE vec<4, std::int32_t>::vec(std::int32_t a) :
+		m(_mm_set1_epi32(a))
+	{}
 
 	// NOTE: SSE2
 	LYAH_INLINE std::int32_t vec<4, std::int32_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec4_m256d.ipp
+++ b/lyah/vec/vec4_m256d.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: AVX
-	LYAH_INLINE vec<4, std::double_t>::vec() : m(_mm256_setzero_pd()) {}
+	LYAH_INLINE vec<4, std::double_t>::vec() :
+		m(_mm256_setzero_pd())
+	{}
 
 	// NOTE: AVX
-	LYAH_INLINE vec<4, std::double_t>::vec(std::double_t x, std::double_t y, std::double_t z, std::double_t w) : m(_mm256_set_pd(w, z, y, x)) {}
+	LYAH_INLINE vec<4, std::double_t>::vec(std::double_t x, std::double_t y, std::double_t z, std::double_t w) :
+		m(_mm256_set_pd(w, z, y, x))
+	{}
 
 	// NOTE: AVX
-	LYAH_INLINE vec<4, std::double_t>::vec(std::double_t a) : m(_mm256_set1_pd(a)) {}
+	LYAH_INLINE vec<4, std::double_t>::vec(std::double_t a) :
+		m(_mm256_set1_pd(a))
+	{}
 
 	// NOTE: AVX2
 	LYAH_INLINE std::double_t vec<4, std::double_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {

--- a/lyah/vec/vec4_m256i.ipp
+++ b/lyah/vec/vec4_m256i.ipp
@@ -3,13 +3,19 @@
 
 namespace lyah {
 	// NOTE: AVX
-	LYAH_INLINE vec<4, std::int64_t>::vec() : m(_mm256_setzero_si256()) {}
+	LYAH_INLINE vec<4, std::int64_t>::vec() :
+		m(_mm256_setzero_si256())
+	{}
 
 	// NOTE: AVX
-	LYAH_INLINE vec<4, std::int64_t>::vec(std::int64_t x, std::int64_t y, std::int64_t z, std::int64_t w) : m(_mm256_set_epi64x(w, z, y, x)) {}
+	LYAH_INLINE vec<4, std::int64_t>::vec(std::int64_t x, std::int64_t y, std::int64_t z, std::int64_t w) :
+		m(_mm256_set_epi64x(w, z, y, x))
+	{}
 
 	// NOTE: AVX
-	LYAH_INLINE vec<4, std::int64_t>::vec(std::int64_t a) : m(_mm256_set1_epi64x(a)) {}
+	LYAH_INLINE vec<4, std::int64_t>::vec(std::int64_t a) :
+		m(_mm256_set1_epi64x(a))
+	{}
 
 	// NOTE: AVX2
 	LYAH_INLINE std::int64_t vec<4, std::int64_t>::operator [](std::size_t index) const LYAH_NOEXCEPT {


### PR DESCRIPTION
Lyah v1.1.1 adds changes and fixes for various bugs I encountered while using it in private projects.

### Fixes

- Add `<cstdint>` include, which was required but went unnoticed due to the includes of the test branch.
- Fix invalid `pow` overload in some vector equality operators.
- Remove `LYAH_CONSTEXPR` mentions on a vector constructor and on the matrix `determinant` function. These methods use SIMD which cannot be declared as `constexpr`.

### Optimization

- Add `LYAH_CALL` on missing functions.

### Documentation

- Update invalid instruction set notes.