### PR TITLE
Release v1.2.0

### DIFF
--- a/lyah/base.hpp
+++ b/lyah/base.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -71,6 +72,12 @@
 	#define LYAH_NODISCARD [[nodiscard]]
 #else
 	#define LYAH_NODISCARD
+#endif
+
+#if LYAH_LANGUAGE >= LYAH_LANGUAGE_CPP14
+	#define LYAH_CONSTEXPR_CPP14 constexpr
+#else
+	#define LYAH_CONSTEXPR_CPP14
 #endif
 
 #if LYAH_LANGUAGE >= LYAH_LANGUAGE_CPP23

--- a/lyah/base.hpp
+++ b/lyah/base.hpp
@@ -49,6 +49,10 @@
 	#define LYAH_LANGUAGE _cplusplus
 #endif
 
+#if LYAH_LANGUAGE < LYAH_LANGUAGE_CPP11
+	#error "Lyah does not support language versions below C++11."
+#endif
+
 #if LYAH_COMPILER == LYAH_COMPILER_CLANG
 	#define LYAH_INLINE __attribute__((always_inline))
 #elif LYAH_COMPILER == LYAH_COMPILER_GCC
@@ -59,17 +63,9 @@
 	#define LYAH_INLINE inline
 #endif
 
-#if LYAH_LANGUAGE >= LYAH_LANGUAGE_CPP11
-	#define LYAH_CONSTEXPR constexpr
-#else
-	#define LYAH_CONSTEXPR
-#endif
+#define LYAH_CONSTEXPR constexpr
 
-#if LYAH_LANGUAGE >= LYAH_LANGUAGE_CPP11
-	#define LYAH_NOEXCEPT noexcept
-#else
-	#define LYAH_NOEXCEPT
-#endif
+#define LYAH_NOEXCEPT noexcept
 
 #if LYAH_LANGUAGE >= LYAH_LANGUAGE_CPP17
 	#define LYAH_NODISCARD [[nodiscard]]
@@ -89,6 +85,7 @@
 	#define LYAH_CONSTEXPR_CPP26
 #endif
 
+// Select instruction set per type.
 #define LYAH_FLOAT32_MAX_INSTRUCTION_SET LYAH_INSTRUCTION_SET_SSE3
 #define LYAH_FLOAT64_MAX_INSTRUCTION_SET LYAH_INSTRUCTION_SET_AVX2
 #define LYAH_INT32_MAX_INSTRUCTION_SET LYAH_INSTRUCTION_SET_SSE3

--- a/lyah/common.hpp
+++ b/lyah/common.hpp
@@ -22,6 +22,22 @@ namespace lyah {
 		return static_cast<std::int64_t>(std::fabs(a));
 	}
 
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::float_t LYAH_CALL ceil(std::float_t a) {
+		return std::ceilf(a);
+	}
+
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::double_t LYAH_CALL ceil(std::double_t a) {
+		return std::ceill(a);
+	}
+
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::float_t LYAH_CALL floor(std::float_t a) {
+		return std::floorf(a);
+	}
+
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP23 LYAH_INLINE std::double_t LYAH_CALL floor(std::double_t a) {
+		return std::floorl(a);
+	}
+
 	LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE std::float_t LYAH_CALL lerp(std::float_t a, std::float_t b, std::float_t t) {
 		return a * (1.0f - t) + b * t;
 	}

--- a/lyah/constants.hpp
+++ b/lyah/constants.hpp
@@ -29,4 +29,9 @@ namespace lyah {
 	LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE T LYAH_CALL pi() {
 		return static_cast<T>(3.141592653589793);
 	}
+
+	template<typename T>
+	LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE T LYAH_CALL tau() {
+		return static_cast<T>(6.283185307179586);
+	}
 }

--- a/lyah/exponential.hpp
+++ b/lyah/exponential.hpp
@@ -6,6 +6,14 @@
 #include "base.hpp"
 
 namespace lyah {
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::float_t LYAH_CALL log2(std::float_t a) {
+		return std::log2f(a);
+	}
+
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::double_t LYAH_CALL log2(std::double_t a) {
+		return std::log2l(a);
+	}
+
 	LYAH_NODISCARD LYAH_CONSTEXPR_CPP26 LYAH_INLINE std::float_t LYAH_CALL pow(std::float_t a, std::float_t e) {
 		return std::powf(a, e);
 	}

--- a/lyah/geometric.hpp
+++ b/lyah/geometric.hpp
@@ -12,6 +12,14 @@ namespace lyah {
 		return a[0] * b[1] - a[1] * b[0];
 	}
 
+	// Returns the "2D cross product" of a and b.
+	// If b is -1, the perpendicular vector to the left of a is returned.
+	// If b is 1, the perpendicular vector to the right of a is returned.
+	template<typename T>
+	LYAH_NODISCARD LYAH_INLINE vec<2, T> LYAH_CALL cross(vec<2, T> a, T b) {
+		return {a[1] * b, a[0] * -b};
+	}
+
 	template<std::size_t C, typename T>
 	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL dot(vec<C, T> a, vec<C, T> b) {
 		return sum(a * b);

--- a/lyah/geometric.hpp
+++ b/lyah/geometric.hpp
@@ -13,12 +13,24 @@ namespace lyah {
 
 	template<std::size_t C, typename T>
 	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL length(vec<C, T> a) {
-		return sqrt(dot(a, a));
+		return sqrt(lengthSquared(a));
+	}
+
+	// Returns the squared length of a.
+	template<std::size_t C, typename T>
+	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL lengthSquared(vec<C, T> a) {
+		return dot(a, a);
 	}
 
 	template<std::size_t C, typename T>
 	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL distance(vec<C, T> a, vec<C, T> b) {
 		return length(b - a);
+	}
+
+	// Returns the squared distance between a and b.
+	template<std::size_t C, typename T>
+	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL distanceSquared(vec<C, T> a, vec<C, T> b) {
+		return lengthSquared(b - a);
 	}
 
 	template<std::size_t C, typename T>

--- a/lyah/geometric.hpp
+++ b/lyah/geometric.hpp
@@ -6,6 +6,12 @@
 #include "base.hpp"
 
 namespace lyah {
+	// Returns the signed parallelogram area formed by a and b.
+	template<typename T>
+	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL area(vec<2, T> a, vec<2, T> b) {
+		return a[0] * b[1] - a[1] * b[0];
+	}
+
 	template<std::size_t C, typename T>
 	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL dot(vec<C, T> a, vec<C, T> b) {
 		return sum(a * b);

--- a/lyah/limits.hpp
+++ b/lyah/limits.hpp
@@ -1,0 +1,23 @@
+// Copyright 2025 Matteo Legagneux.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "base.hpp"
+
+namespace lyah {
+	template<typename T>
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP14 LYAH_INLINE T LYAH_CALL min(T a, T b) {
+		return std::min(a, b);
+	}
+
+	template<typename T>
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP14 LYAH_INLINE T LYAH_CALL max(T a, T b) {
+		return std::max(a, b);
+	}
+
+	template<typename T>
+	LYAH_NODISCARD LYAH_CONSTEXPR_CPP14 LYAH_INLINE T LYAH_CALL clamp(T a, T min, T max) {
+		return lyah::min(lyah::max(a, min), max);
+	}
+}

--- a/lyah/lyah.hpp
+++ b/lyah/lyah.hpp
@@ -14,4 +14,5 @@
 #include "common.hpp"
 #include "exponential.hpp"
 #include "geometric.hpp"
+#include "limits.hpp"
 #include "trigonometric.hpp"

--- a/lyah/mat/mat2x2.hpp
+++ b/lyah/mat/mat2x2.hpp
@@ -15,6 +15,16 @@ namespace lyah {
 			};
 		}
 
+		LYAH_NODISCARD LYAH_INLINE static mat<2, 2, T> LYAH_CALL rotation(T a) {
+			const T c = cos(a);
+			const T s = sin(a);
+
+			return {
+				c, -s,
+				s,  c,
+			};
+		}
+
 		vec<2, T> m[2];
 
 		LYAH_NODISCARD LYAH_INLINE mat() :

--- a/lyah/mat/mat2x2.hpp
+++ b/lyah/mat/mat2x2.hpp
@@ -8,52 +8,55 @@
 namespace lyah {
 	template<typename T>
 	struct mat<2, 2, T> {
-		LYAH_NODISCARD LYAH_INLINE static mat<2, 2, T> LYAH_CALL identity() {
-			return {
-				static_cast<T>(1), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(1),
-			};
-		}
+		public:
+			LYAH_NODISCARD LYAH_INLINE static mat<2, 2, T> LYAH_CALL identity() {
+				return {
+					static_cast<T>(1), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(1),
+				};
+			}
 
-		LYAH_NODISCARD LYAH_INLINE static mat<2, 2, T> LYAH_CALL rotation(T a) {
-			const T c = cos(a);
-			const T s = sin(a);
+			LYAH_NODISCARD LYAH_INLINE static mat<2, 2, T> LYAH_CALL rotation(T a) {
+				const T c = cos(a);
+				const T s = sin(a);
 
-			return {
-				c, -s,
-				s,  c,
-			};
-		}
+				return {
+					c, -s,
+					s,  c,
+				};
+			}
 
-		vec<2, T> m[2];
+		public:
+			LYAH_NODISCARD LYAH_INLINE mat() :
+				m{}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat() :
-			m{}
-		{}
+			LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m10, T m11) :
+				m{{m00, m01}, {m10, m11}}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m10, T m11) :
-			m{{m00, m01}, {m10, m11}}
-		{}
+			LYAH_NODISCARD LYAH_INLINE mat(vec<2, T> m0, vec<2, T> m1) :
+				m{m0, m1}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(vec<2, T> m0, vec<2, T> m1) :
-			m{m0, m1}
-		{}
+			template<typename U>
+			LYAH_NODISCARD LYAH_INLINE explicit mat(mat<2, 2, U> a) :
+				m{vec<2, T>(a.m[0]), vec<2, T>(a.m[1])}
+			{}
 
-		template<typename U>
-		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<2, 2, U> a) :
-			m{vec<2, T>(a.m[0]), vec<2, T>(a.m[1])}
-		{}
+			LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<2, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
+				LYAH_ASSERT(index < 2);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<2, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
-			LYAH_ASSERT(index < 2);
+				return m[index];
+			}
 
-			return m[index];
-		}
+			LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE vec<2, T>& LYAH_CALL operator [](std::size_t index) LYAH_NOEXCEPT {
+				LYAH_ASSERT(index < 2);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE vec<2, T>& LYAH_CALL operator [](std::size_t index) LYAH_NOEXCEPT {
-			LYAH_ASSERT(index < 2);
+				return m[index];
+			}
 
-			return m[index];
-		}
+		public:
+			vec<2, T> m[2];
 	};
 }

--- a/lyah/mat/mat3x3.hpp
+++ b/lyah/mat/mat3x3.hpp
@@ -8,71 +8,74 @@
 namespace lyah {
 	template<typename T>
 	struct mat<3, 3, T> {
-		LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL identity() {
-			return {
-				static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
-			};
-		}
+		public:
+			LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL identity() {
+				return {
+					static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
+				};
+			}
 
-		LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL translation(vec<2, T> a) {
-			return {
-				static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
-				a[0],              a[1],              static_cast<T>(1),
-			};
-		}
+			LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL translation(vec<2, T> a) {
+				return {
+					static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
+					a[0],              a[1],              static_cast<T>(1),
+				};
+			}
 
-		// NOTE: Rotates around the Z axis.
-		LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL rotation(T a) {
-			const T c = cos(a);
-			const T s = sin(a);
+			// NOTE: Rotates around the Z axis.
+			LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL rotation(T a) {
+				const T c = cos(a);
+				const T s = sin(a);
 
-			return {
-				c,                -s,                 static_cast<T>(0),
-				s,                 c,                 static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
-			};
-		}
+				return {
+					c,                -s,                 static_cast<T>(0),
+					s,                 c,                 static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
+				};
+			}
 
-		LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL scaling(vec<2, T> a) {
-			return {
-				a[0],              static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), a[1],              static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
-			};
-		}
+			LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL scaling(vec<2, T> a) {
+				return {
+					a[0],              static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), a[1],              static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
+				};
+			}
 
-		vec<3, T> m[3];
+		public:
+			LYAH_NODISCARD LYAH_INLINE mat() :
+				m{}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat() :
-			m{}
-		{}
+			LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m02, T m10, T m11, T m12, T m20, T m21, T m22) :
+				m{{m00, m01, m02}, {m10, m11, m12}, {m20, m21, m22}}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m02, T m10, T m11, T m12, T m20, T m21, T m22) :
-			m{{m00, m01, m02}, {m10, m11, m12}, {m20, m21, m22}}
-		{}
+			LYAH_NODISCARD LYAH_INLINE mat(vec<3, T> m0, vec<3, T> m1, vec<3, T> m2) :
+				m{m0, m1, m2}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(vec<3, T> m0, vec<3, T> m1, vec<3, T> m2) :
-			m{m0, m1, m2}
-		{}
+			template<typename U>
+			LYAH_NODISCARD LYAH_INLINE explicit mat(mat<3, 3, U> a) :
+				m{vec<3, T>(a.m[0]), vec<3, T>(a.m[1]), vec<3, T>(a.m[2])}
+			{}
 
-		template<typename U>
-		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<3, 3, U> a) :
-			m{vec<3, T>(a.m[0]), vec<3, T>(a.m[1]), vec<3, T>(a.m[2])}
-		{}
+			LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<3, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
+				LYAH_ASSERT(index < 3);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<3, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
-			LYAH_ASSERT(index < 3);
+				return m[index];
+			}
 
-			return m[index];
-		}
+			LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE vec<3, T>& LYAH_CALL operator [](std::size_t index) LYAH_NOEXCEPT {
+				LYAH_ASSERT(index < 3);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE vec<3, T>& LYAH_CALL operator [](std::size_t index) LYAH_NOEXCEPT {
-			LYAH_ASSERT(index < 3);
+				return m[index];
+			}
 
-			return m[index];
-		}
+		public:
+			vec<3, T> m[3];
 	};
 }

--- a/lyah/mat/mat3x3.hpp
+++ b/lyah/mat/mat3x3.hpp
@@ -24,6 +24,7 @@ namespace lyah {
 			};
 		}
 
+		// NOTE: Rotates around the Z axis.
 		LYAH_NODISCARD LYAH_INLINE static mat<3, 3, T> LYAH_CALL rotation(T a) {
 			const T c = cos(a);
 			const T s = sin(a);

--- a/lyah/mat/mat4x4.hpp
+++ b/lyah/mat/mat4x4.hpp
@@ -8,105 +8,108 @@
 namespace lyah {
 	template<typename T>
 	struct mat<4, 4, T> {
-		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL identity() {
-			return {
-				static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
-			};
-		}
+		public:
+			LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL identity() {
+				return {
+					static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
+				};
+			}
 
-		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL translation(vec<3, T> a) {
-			return {
-				static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
-				a[0],              a[1],              a[2],              static_cast<T>(1),
-			};
-		}
+			LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL translation(vec<3, T> a) {
+				return {
+					static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(1), static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
+					a[0],              a[1],              a[2],              static_cast<T>(1),
+				};
+			}
 
-		// axis is assumed to be normalized.
-		// angle is in radians.
-		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL rotation(vec<3, T> axis, T angle) {
-			const T cosAngle = cos(angle);
-			const T sinAngle = sin(angle);
-			const T one_cosAngle = static_cast<T>(1) - cosAngle;
+			// axis is assumed to be normalized.
+			// angle is in radians.
+			LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL rotation(vec<3, T> axis, T angle) {
+				const T cosAngle = cos(angle);
+				const T sinAngle = sin(angle);
+				const T one_cosAngle = static_cast<T>(1) - cosAngle;
 
-			return {
-				axis[0] * axis[0] * one_cosAngle + cosAngle,           axis[0] * axis[1] * one_cosAngle + axis[2] * sinAngle, axis[0] * axis[2] * one_cosAngle - axis[1] * sinAngle, static_cast<T>(0),
-				axis[0] * axis[1] * one_cosAngle - axis[2] * sinAngle, axis[1] * axis[1] * one_cosAngle + cosAngle,           axis[1] * axis[2] * one_cosAngle + axis[0] * sinAngle, static_cast<T>(0),
-				axis[0] * axis[2] * one_cosAngle + axis[1] * sinAngle, axis[1] * axis[2] * one_cosAngle - axis[0] * sinAngle, axis[2] * axis[2] * one_cosAngle + cosAngle,           static_cast<T>(0),
-				static_cast<T>(0),                                     static_cast<T>(0),                                     static_cast<T>(0),                                     static_cast<T>(1),
-			};
-		}
+				return {
+					axis[0] * axis[0] * one_cosAngle + cosAngle,           axis[0] * axis[1] * one_cosAngle + axis[2] * sinAngle, axis[0] * axis[2] * one_cosAngle - axis[1] * sinAngle, static_cast<T>(0),
+					axis[0] * axis[1] * one_cosAngle - axis[2] * sinAngle, axis[1] * axis[1] * one_cosAngle + cosAngle,           axis[1] * axis[2] * one_cosAngle + axis[0] * sinAngle, static_cast<T>(0),
+					axis[0] * axis[2] * one_cosAngle + axis[1] * sinAngle, axis[1] * axis[2] * one_cosAngle - axis[0] * sinAngle, axis[2] * axis[2] * one_cosAngle + cosAngle,           static_cast<T>(0),
+					static_cast<T>(0),                                     static_cast<T>(0),                                     static_cast<T>(0),                                     static_cast<T>(1),
+				};
+			}
 
-		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL scaling(vec<3, T> a) {
-			return {
-				a[0],              static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), a[1],              static_cast<T>(0), static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), a[2],              static_cast<T>(0),
-				static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
-			};
-		}
+			LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL scaling(vec<3, T> a) {
+				return {
+					a[0],              static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), a[1],              static_cast<T>(0), static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), a[2],              static_cast<T>(0),
+					static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
+				};
+			}
 
-		// Returns a left-handed matrix.
-		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL orthographic(T left, T right, T bottom, T top, T near, T far) {
-			const vec<4, T> m0 = vec<4, T>(static_cast<T>(2), static_cast<T>(0), static_cast<T>(0), -(left + right)) / (right - left);
-			const vec<4, T> m1 = vec<4, T>(static_cast<T>(0), static_cast<T>(2), static_cast<T>(0), -(bottom + top)) / (top - bottom);
-			const vec<4, T> m2 = vec<4, T>(static_cast<T>(0), static_cast<T>(0), static_cast<T>(2), -(near + far)) / (far - near);
-			const vec<4, T> m3 = {static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1)};
+			// Returns a left-handed matrix.
+			LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL orthographic(T left, T right, T bottom, T top, T near, T far) {
+				const vec<4, T> m0 = vec<4, T>(static_cast<T>(2), static_cast<T>(0), static_cast<T>(0), -(left + right)) / (right - left);
+				const vec<4, T> m1 = vec<4, T>(static_cast<T>(0), static_cast<T>(2), static_cast<T>(0), -(bottom + top)) / (top - bottom);
+				const vec<4, T> m2 = vec<4, T>(static_cast<T>(0), static_cast<T>(0), static_cast<T>(2), -(near + far)) / (far - near);
+				const vec<4, T> m3 = {static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1)};
 
-			return {m0, m1, m2, m3};
-		}
+				return {m0, m1, m2, m3};
+			}
 
-		// Returns a left-handed matrix.
-		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL lookAt(vec<3, T> eye, vec<3, T> center, vec<3, T> up) {
-			const vec<3, T> f = normalized(center - eye);
-			const vec<3, T> r = normalized(cross(up, f));
-			const vec<3, T> u = cross(f, r);
+			// Returns a left-handed matrix.
+			LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL lookAt(vec<3, T> eye, vec<3, T> center, vec<3, T> up) {
+				const vec<3, T> f = normalized(center - eye);
+				const vec<3, T> r = normalized(cross(up, f));
+				const vec<3, T> u = cross(f, r);
 
-			return {
-				 r[0],         u[0],         f[0],         static_cast<T>(0),
-				 r[1],         u[1],         f[1],         static_cast<T>(0),
-				 r[2],         u[2],         f[2],         static_cast<T>(0),
-				-dot(r, eye), -dot(u, eye), -dot(f, eye),  static_cast<T>(1),
-			};
-		}
+				return {
+					 r[0],         u[0],         f[0],         static_cast<T>(0),
+					 r[1],         u[1],         f[1],         static_cast<T>(0),
+					 r[2],         u[2],         f[2],         static_cast<T>(0),
+					-dot(r, eye), -dot(u, eye), -dot(f, eye),  static_cast<T>(1),
+				};
+			}
 
-		vec<4, T> m[4];
+		public:
+			LYAH_NODISCARD LYAH_INLINE mat() :
+				m{}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat() :
-			m{}
-		{}
+			LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m02, T m03, T m10, T m11, T m12, T m13, T m20, T m21, T m22, T m23, T m30, T m31, T m32, T m33) :
+				m{{m00, m01, m02, m03}, {m10, m11, m12, m13}, {m20, m21, m22, m23}, {m30, m31, m32, m33}}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(T m00, T m01, T m02, T m03, T m10, T m11, T m12, T m13, T m20, T m21, T m22, T m23, T m30, T m31, T m32, T m33) :
-			m{{m00, m01, m02, m03}, {m10, m11, m12, m13}, {m20, m21, m22, m23}, {m30, m31, m32, m33}}
-		{}
+			LYAH_NODISCARD LYAH_INLINE mat(vec<4, T> m0, vec<4, T> m1, vec<4, T> m2, vec<4, T> m3) :
+				m{m0, m1, m2, m3}
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE mat(vec<4, T> m0, vec<4, T> m1, vec<4, T> m2, vec<4, T> m3) :
-			m{m0, m1, m2, m3}
-		{}
+			template<typename U>
+			LYAH_NODISCARD LYAH_INLINE explicit mat(mat<4, 4, U> a) :
+				m{vec<4, T>(a.m[0]), vec<4, T>(a.m[1]), vec<4, T>(a.m[2]), vec<4, T>(a.m[3])}
+			{}
 
-		template<typename U>
-		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<4, 4, U> a) :
-			m{vec<4, T>(a.m[0]), vec<4, T>(a.m[1]), vec<4, T>(a.m[2]), vec<4, T>(a.m[3])}
-		{}
+			// Returns a rotation matrix computed from a.
+			// a is assumed to be normalized.
+			LYAH_NODISCARD explicit mat(quat<T> a);
 
-		// Returns a rotation matrix computed from a.
-		// a is assumed to be normalized.
-		LYAH_NODISCARD explicit mat(quat<T> a);
+			LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<4, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
+				LYAH_ASSERT(index < 4);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<4, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
-			LYAH_ASSERT(index < 4);
+				return m[index];
+			}
 
-			return m[index];
-		}
+			LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE vec<4, T>& LYAH_CALL operator [](std::size_t index) LYAH_NOEXCEPT {
+				LYAH_ASSERT(index < 4);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE vec<4, T>& LYAH_CALL operator [](std::size_t index) LYAH_NOEXCEPT {
-			LYAH_ASSERT(index < 4);
+				return m[index];
+			}
 
-			return m[index];
-		}
+		public:
+			vec<4, T> m[4];
 	};
 }

--- a/lyah/mat/mat4x4.hpp
+++ b/lyah/mat/mat4x4.hpp
@@ -88,14 +88,14 @@ namespace lyah {
 			m{m0, m1, m2, m3}
 		{}
 
-		// Returns a rotation matrix computed from a.
-		// a is assumed to be normalized.
-		LYAH_NODISCARD explicit mat(quat<T> a);
-
 		template<typename U>
 		LYAH_NODISCARD LYAH_INLINE explicit mat(mat<4, 4, U> a) :
 			m{vec<4, T>(a.m[0]), vec<4, T>(a.m[1]), vec<4, T>(a.m[2]), vec<4, T>(a.m[3])}
 		{}
+
+		// Returns a rotation matrix computed from a.
+		// a is assumed to be normalized.
+		LYAH_NODISCARD explicit mat(quat<T> a);
 
 		LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE const vec<4, T>& LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT {
 			LYAH_ASSERT(index < 4);

--- a/lyah/quat/quat.hpp
+++ b/lyah/quat/quat.hpp
@@ -17,6 +17,7 @@ namespace lyah {
 			LYAH_NODISCARD static quat<T> LYAH_CALL identity();
 			LYAH_NODISCARD static quat<T> LYAH_CALL axisAngle(vec<3, T> axis, T angle);
 
+		public:
 			LYAH_NODISCARD quat();
 			LYAH_NODISCARD quat(T w, T x, T y, T z);
 

--- a/lyah/quat/quat.hpp
+++ b/lyah/quat/quat.hpp
@@ -20,10 +20,10 @@ namespace lyah {
 		LYAH_NODISCARD quat();
 		LYAH_NODISCARD quat(T w, T x, T y, T z);
 
-		LYAH_NODISCARD LYAH_CONSTEXPR explicit quat(__m_t m);
+		LYAH_NODISCARD explicit quat(__m_t m);
 
 		template<typename U>
-		LYAH_NODISCARD quat(quat<U> a);
+		LYAH_NODISCARD explicit quat(quat<U> a);
 
 		LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
 

--- a/lyah/quat/quat.hpp
+++ b/lyah/quat/quat.hpp
@@ -10,26 +10,29 @@
 namespace lyah {
 	template<typename T>
 	struct quat {
-		using __m_t = typename internal::quat_t<T>::m_t;
+		public:
+			using __m_t = typename internal::quat_t<T>::m_t;
 
-		__m_t m;
+		public:
+			LYAH_NODISCARD static quat<T> LYAH_CALL identity();
+			LYAH_NODISCARD static quat<T> LYAH_CALL axisAngle(vec<3, T> axis, T angle);
 
-		LYAH_NODISCARD static quat<T> LYAH_CALL identity();
-		LYAH_NODISCARD static quat<T> LYAH_CALL axisAngle(vec<3, T> axis, T angle);
+			LYAH_NODISCARD quat();
+			LYAH_NODISCARD quat(T w, T x, T y, T z);
 
-		LYAH_NODISCARD quat();
-		LYAH_NODISCARD quat(T w, T x, T y, T z);
+			LYAH_NODISCARD explicit quat(__m_t m);
 
-		LYAH_NODISCARD explicit quat(__m_t m);
+			template<typename U>
+			LYAH_NODISCARD explicit quat(quat<U> a);
 
-		template<typename U>
-		LYAH_NODISCARD explicit quat(quat<U> a);
+			LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
 
-		LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
+			LYAH_NODISCARD T LYAH_CALL w() const;
 
-		LYAH_NODISCARD T LYAH_CALL w() const;
+			LYAH_NODISCARD vec<3, T> LYAH_CALL xyz() const;
 
-		LYAH_NODISCARD vec<3, T> LYAH_CALL xyz() const;
+		public:
+			__m_t m;
 	};
 }
 

--- a/lyah/quat/quat.ipp
+++ b/lyah/quat/quat.ipp
@@ -16,7 +16,7 @@ namespace lyah {
 	}
 
 	template<typename T>
-	LYAH_NODISCARD LYAH_CONSTEXPR LYAH_INLINE quat<T>::quat(__m_t m) :
+	LYAH_NODISCARD LYAH_INLINE quat<T>::quat(__m_t m) :
 		m(m)
 	{}
 

--- a/lyah/quat/quat.ipp
+++ b/lyah/quat/quat.ipp
@@ -93,7 +93,12 @@ namespace lyah {
 
 	template<typename T>
 	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL length(quat<T> a) {
-		return sqrt(dot(a, a));
+		return sqrt(lengthSquared(a));
+	}
+
+	template<typename T>
+	LYAH_NODISCARD LYAH_INLINE T LYAH_CALL lengthSquared(quat<T> a) {
+		return dot(a, a);
 	}
 
 	template<typename T>

--- a/lyah/vec/m128/common.ipp
+++ b/lyah/vec/m128/common.ipp
@@ -26,14 +26,6 @@ namespace lyah {
 	} */
 
 	// NOTE: SSE3
-	/* LYAH_NODISCARD LYAH_INLINE std::float_t LYAH_CALL max(vec<2, std::float_t> a) {
-		const __m128 hdup = _mm_movehdup_ps(a.m);
-		const __m128 max = _mm_max_ss(a.m, hdup);
-
-		return _mm_cvtss_f32(max);
-	} */
-
-	// NOTE: SSE3
 	/* LYAH_NODISCARD LYAH_INLINE std::float_t LYAH_CALL min(vec<2, std::float_t> a) {
 		const __m128 hdup = _mm_movehdup_ps(a.m);
 		const __m128 min = _mm_min_ss(a.m, hdup);
@@ -41,18 +33,26 @@ namespace lyah {
 		return _mm_cvtss_f32(min);
 	} */
 
+	// NOTE: SSE3
+	/* LYAH_NODISCARD LYAH_INLINE std::float_t LYAH_CALL max(vec<2, std::float_t> a) {
+		const __m128 hdup = _mm_movehdup_ps(a.m);
+		const __m128 max = _mm_max_ss(a.m, hdup);
+
+		return _mm_cvtss_f32(max);
+	} */
+
 	// NOTE: SSE
 	template<std::size_t C>
-	LYAH_NODISCARD LYAH_INLINE vec<C, std::float_t> LYAH_CALL max(vec<C, std::float_t> a, vec<C, std::float_t> b) {
-		a.m = _mm_max_ps(a.m, b.m);
+	LYAH_NODISCARD LYAH_INLINE vec<C, std::float_t> LYAH_CALL min(vec<C, std::float_t> a, vec<C, std::float_t> b) {
+		a.m = _mm_min_ps(a.m, b.m);
 
 		return a;
 	}
 
 	// NOTE: SSE
 	template<std::size_t C>
-	LYAH_NODISCARD LYAH_INLINE vec<C, std::float_t> LYAH_CALL min(vec<C, std::float_t> a, vec<C, std::float_t> b) {
-		a.m = _mm_min_ps(a.m, b.m);
+	LYAH_NODISCARD LYAH_INLINE vec<C, std::float_t> LYAH_CALL max(vec<C, std::float_t> a, vec<C, std::float_t> b) {
+		a.m = _mm_max_ps(a.m, b.m);
 
 		return a;
 	}

--- a/lyah/vec/m128d/common.ipp
+++ b/lyah/vec/m128d/common.ipp
@@ -3,14 +3,6 @@
 
 namespace lyah {
 	// NOTE: SSE2
-	/* LYAH_NODISCARD LYAH_INLINE std::double_t LYAH_CALL max(vec<2, std::double_t> a) {
-		const __m128d hl = _mm_castps_pd(_mm_movehl_ps(_mm_undefined_ps(), _mm_castpd_ps(a.m)));
-		const __m128d max = _mm_max_sd(a.m, hl);
-
-		return _mm_cvtsd_f64(max);
-	} */
-
-	// NOTE: SSE2
 	/* LYAH_NODISCARD LYAH_INLINE std::double_t LYAH_CALL min(vec<2, std::double_t> a) {
 		const __m128d hl = _mm_castps_pd(_mm_movehl_ps(_mm_undefined_ps(), _mm_castpd_ps(a.m)));
 		const __m128d min = _mm_min_sd(a.m, hl);
@@ -19,15 +11,23 @@ namespace lyah {
 	} */
 
 	// NOTE: SSE2
-	LYAH_NODISCARD LYAH_INLINE vec<2, std::double_t> LYAH_CALL max(vec<2, std::double_t> a, vec<2, std::double_t> b) {
-		a.m = _mm_max_pd(a.m, b.m);
+	/* LYAH_NODISCARD LYAH_INLINE std::double_t LYAH_CALL max(vec<2, std::double_t> a) {
+		const __m128d hl = _mm_castps_pd(_mm_movehl_ps(_mm_undefined_ps(), _mm_castpd_ps(a.m)));
+		const __m128d max = _mm_max_sd(a.m, hl);
+
+		return _mm_cvtsd_f64(max);
+	} */
+
+	// NOTE: SSE2
+	LYAH_NODISCARD LYAH_INLINE vec<2, std::double_t> LYAH_CALL min(vec<2, std::double_t> a, vec<2, std::double_t> b) {
+		a.m = _mm_min_pd(a.m, b.m);
 
 		return a;
 	}
 
 	// NOTE: SSE2
-	LYAH_NODISCARD LYAH_INLINE vec<2, std::double_t> LYAH_CALL min(vec<2, std::double_t> a, vec<2, std::double_t> b) {
-		a.m = _mm_min_pd(a.m, b.m);
+	LYAH_NODISCARD LYAH_INLINE vec<2, std::double_t> LYAH_CALL max(vec<2, std::double_t> a, vec<2, std::double_t> b) {
+		a.m = _mm_max_pd(a.m, b.m);
 
 		return a;
 	}

--- a/lyah/vec/m256d/common.ipp
+++ b/lyah/vec/m256d/common.ipp
@@ -4,16 +4,16 @@
 namespace lyah {
 	// NOTE: AVX
 	template<std::size_t C>
-	LYAH_NODISCARD LYAH_INLINE vec<C, std::double_t> LYAH_CALL max(vec<C, std::double_t> a, vec<C, std::double_t> b) {
-		a.m = _mm256_max_pd(a.m, b.m);
+	LYAH_NODISCARD LYAH_INLINE vec<C, std::double_t> LYAH_CALL min(vec<C, std::double_t> a, vec<C, std::double_t> b) {
+		a.m = _mm256_min_pd(a.m, b.m);
 
 		return a;
 	}
 
 	// NOTE: AVX
 	template<std::size_t C>
-	LYAH_NODISCARD LYAH_INLINE vec<C, std::double_t> LYAH_CALL min(vec<C, std::double_t> a, vec<C, std::double_t> b) {
-		a.m = _mm256_min_pd(a.m, b.m);
+	LYAH_NODISCARD LYAH_INLINE vec<C, std::double_t> LYAH_CALL max(vec<C, std::double_t> a, vec<C, std::double_t> b) {
+		a.m = _mm256_max_pd(a.m, b.m);
 
 		return a;
 	}

--- a/lyah/vec/vec2.hpp
+++ b/lyah/vec/vec2.hpp
@@ -10,22 +10,25 @@
 namespace lyah {
 	template<typename T>
 	struct vec<2, T> {
-		using __m_t = typename internal::vec_t<2, T>::m_t;
+		public:
+			using __m_t = typename internal::vec_t<2, T>::m_t;
 
-		__m_t m;
+		public:
+			LYAH_NODISCARD vec();
+			LYAH_NODISCARD vec(T x, T y);
+			LYAH_NODISCARD explicit vec(T a);
 
-		LYAH_NODISCARD vec();
-		LYAH_NODISCARD vec(T x, T y);
-		LYAH_NODISCARD explicit vec(T a);
+			LYAH_NODISCARD explicit vec(__m_t m) :
+				m(m)
+			{}
 
-		LYAH_NODISCARD explicit vec(__m_t m) :
-			m(m)
-		{}
+			template<typename U>
+			LYAH_NODISCARD explicit vec(vec<2, U> a) : m(internal::convert<typename vec<2, U>::__m_t, __m_t>(a.m)) {}
 
-		template<typename U>
-		LYAH_NODISCARD explicit vec(vec<2, U> a) : m(internal::convert<typename vec<2, U>::__m_t, __m_t>(a.m)) {}
+			LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
 
-		LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
+		public:
+			__m_t m;
 	};
 }
 

--- a/lyah/vec/vec3.hpp
+++ b/lyah/vec/vec3.hpp
@@ -10,22 +10,25 @@
 namespace lyah {
 	template<typename T>
 	struct vec<3, T> {
-		using __m_t = typename internal::vec_t<3, T>::m_t;
+		public:
+			using __m_t = typename internal::vec_t<3, T>::m_t;
 
-		__m_t m;
+		public:
+			LYAH_NODISCARD vec();
+			LYAH_NODISCARD vec(T x, T y, T z);
+			LYAH_NODISCARD explicit vec(T a);
 
-		LYAH_NODISCARD vec();
-		LYAH_NODISCARD vec(T x, T y, T z);
-		LYAH_NODISCARD explicit vec(T a);
+			LYAH_NODISCARD explicit vec(__m_t m) :
+				m(m)
+			{}
 
-		LYAH_NODISCARD explicit vec(__m_t m) :
-			m(m)
-		{}
+			template<typename U>
+			LYAH_NODISCARD explicit vec(vec<3, U> a) : m(internal::convert<typename vec<3, U>::__m_t, __m_t>(a.m)) {}
 
-		template<typename U>
-		LYAH_NODISCARD explicit vec(vec<3, U> a) : m(internal::convert<typename vec<3, U>::__m_t, __m_t>(a.m)) {}
+			LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
 
-		LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
+		public:
+			__m_t m;
 	};
 }
 

--- a/lyah/vec/vec4.hpp
+++ b/lyah/vec/vec4.hpp
@@ -10,22 +10,25 @@
 namespace lyah {
 	template<typename T>
 	struct vec<4, T> {
-		using __m_t = typename internal::vec_t<4, T>::m_t;
+		public:
+			using __m_t = typename internal::vec_t<4, T>::m_t;
 
-		__m_t m;
+		public:
+			LYAH_NODISCARD vec();
+			LYAH_NODISCARD vec(T x, T y, T z, T w);
+			LYAH_NODISCARD explicit vec(T a);
 
-		LYAH_NODISCARD vec();
-		LYAH_NODISCARD vec(T x, T y, T z, T w);
-		LYAH_NODISCARD explicit vec(T a);
+			LYAH_NODISCARD LYAH_INLINE explicit vec(__m_t m) :
+				m(m)
+			{}
 
-		LYAH_NODISCARD LYAH_INLINE explicit vec(__m_t m) :
-			m(m)
-		{}
+			template<typename U>
+			LYAH_NODISCARD explicit vec(vec<4, U> a) : m(internal::convert<typename vec<4, U>::__m_t, __m_t>(a.m)) {}
 
-		template<typename U>
-		LYAH_NODISCARD explicit vec(vec<4, U> a) : m(internal::convert<typename vec<4, U>::__m_t, __m_t>(a.m)) {}
+			LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
 
-		LYAH_NODISCARD T LYAH_CALL operator [](std::size_t index) const LYAH_NOEXCEPT;
+		public:
+			__m_t m;
 	};
 }
 


### PR DESCRIPTION
Lyah 1.2.0 adds many utilities for common operations.  
For more info, read the [API documentation](https://debaze.github.io/lyah).

### Features

- Add <samp>T distanceSquared(vec&lt;C, T&gt; a)</samp>
- Add <samp>T distanceSquared(quat&lt;T&gt; a)</samp>
- Add <samp>T lengthSquared(vec&lt;C, T&gt; a)</samp>
- Add <samp>T lengthSquared(quat&lt;T&gt; a)</samp>
- Add <samp>std::float_t area(vec&lt;2, std::float_t&gt; a, vec&lt;2, std::float_t&gt; b)</samp>
- Add <samp>std::double_t area(vec&lt;2, std::double_t&gt; a, vec&lt;2, std::double_t&gt; b)</samp>
- Add <samp>std::float_t tau()</samp>
- Add <samp>std::double_t tau()</samp>
- Add <samp>std::float_t min(std::float_t a, std::float_t b)</samp>
- Add <samp>std::double_t min(std::double_t a, std::double_t b)</samp>
- Add <samp>std::int32_t min(std::int32_t a, std::int32_t b)</samp>
- Add <samp>std::int64_t min(std::int64_t a, std::int64_t b)</samp>
- Add <samp>std::float_t max(std::float_t a, std::float_t b)</samp>
- Add <samp>std::double_t max(std::double_t a, std::double_t b)</samp>
- Add <samp>std::int32_t max(std::int32_t a, std::int32_t b)</samp>
- Add <samp>std::int64_t max(std::int64_t a, std::int64_t b)</samp>
- Add <samp>std::float_t clamp(std::float_t a, std::float_t min, std::float_t max)</samp>
- Add <samp>std::double_t clamp(std::double_t a, std::double_t min, std::double_t max)</samp>
- Add <samp>std::int32_t clamp(std::int32_t a, std::int32_t min, std::int32_t max)</samp>
- Add <samp>std::int64_t clamp(std::int64_t a, std::int64_t min, std::int64_t max)</samp>
- Add <samp>vec&lt;C, T&gt; clamp(vec&lt;C, T&gt; a, vec&lt;C, T&gt; min, vec&lt;C, T&gt; max)</samp> (vertical clamp)
- Add <samp>vec&lt;2, T&gt; cross(vec&lt;2, T&gt; a, T b)</samp> ("2D vector cross product")
- Add <samp>std::float_t ceil(std::float_t a)</samp>
- Add <samp>std::double_t ceil(std::double_t a)</samp>
- Add <samp>std::float_t floor(std::float_t a)</samp>
- Add <samp>std::double_t floor(std::double_t a)</samp>
- Add <samp>std::float_t log2(std::float_t a)</samp>
- Add <samp>std::double_t log2(std::double_t a)</samp>

### Fixes

- Remove the `constexpr` attribute in the quaternion SIMD constructor
- Make the quaternion converting constructor explicit.
- C++ versions below C++11 are unsupported. A compile-time error will be thrown when trying to build Lyah with an unsupported version.

### Documentation

- Rewrite some comments about method argument requirements
- Specify which class the static methods belong to in the API documentation

### Testing

- Test 64-bit floating point constant overloads